### PR TITLE
Fix server start race condition

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -28,7 +28,9 @@ async function connectDB() {
     process.exit(1);
   }
 }
-connectDB();
+connectDB().then(() => {
+  app.listen(PORT, () => console.log(`Serveur démarré sur le port ${PORT}`));
+});
 
 app.get("/api/count", async (req, res) => {
   try {
@@ -47,4 +49,3 @@ app.all("*", (req, res) => {
   res.status(404).end();
 });
 
-app.listen(PORT, () => console.log(`Serveur démarré sur le port ${PORT}`));


### PR DESCRIPTION
## Summary
- wait for MongoDB connection before starting server

## Testing
- `npm install` within `client`
- `npm run lint` within `client`


------
https://chatgpt.com/codex/tasks/task_e_684fcf6b90908322a3cd12ed2af16575